### PR TITLE
Pin the Terminus Version

### DIFF
--- a/action.yml
+++ b/action.yml
@@ -35,8 +35,8 @@ runs:
 
         # Also, install Terminus if missing.
         hash terminus 2> /dev/null || \
-          curl -O https://github.com/pantheon-systems/terminus/releases/download/3.6.2/terminus.phar && \
-          php installer.phar install &> /dev/null
+          curl -O https://raw.githubusercontent.com/pantheon-systems/terminus-installer/master/builds/installer.phar && \
+          php installer.phar install --install-version=3.6.2 &> /dev/null
       shell: bash
 
     - name: Set some environment variables when using DDEV

--- a/action.yml
+++ b/action.yml
@@ -35,7 +35,7 @@ runs:
 
         # Also, install Terminus if missing.
         hash terminus 2> /dev/null || \
-          curl -O https://raw.githubusercontent.com/pantheon-systems/terminus-installer/master/builds/installer.phar && \
+          curl -O https://github.com/pantheon-systems/terminus/releases/download/3.6.2/terminus.phar && \
           php installer.phar install &> /dev/null
       shell: bash
 


### PR DESCRIPTION
To prevent terminus errors regarding PHP versions on deployment, let's try to pin the version of Terminus we're using.